### PR TITLE
Use custom datadir if specified

### DIFF
--- a/src/komodo_validation015.h
+++ b/src/komodo_validation015.h
@@ -1029,9 +1029,9 @@ void komodo_notarized_update(int32_t nHeight,int32_t notarized_height,uint256 no
         //decode_hex(NOTARY_PUBKEY33,33,(char *)NOTARY_PUBKEY.c_str());
         pthread_mutex_init(&komodo_mutex,NULL);
 #ifdef _WIN32
-        sprintf(fname,"%s\\notarizations",GetDefaultDataDir().string().c_str());
+        sprintf(fname,"%s\\notarizations",GetDataDir().string().c_str());
 #else
-        sprintf(fname,"%s/notarizations",GetDefaultDataDir().string().c_str());
+        sprintf(fname,"%s/notarizations",GetDataDir().string().c_str());
 #endif
         printf("fname.(%s)\n",fname);
         if ( (fp= fopen(fname,"rb+")) == 0 )


### PR DESCRIPTION
Currently the notarization file will not be stored in correct directory if a custom -datadir is specified.

This is not a consensus change.